### PR TITLE
Don't set fractional position

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -59,8 +59,8 @@ function moveWindow(client, position) {
     }
 
     client.frameGeometry = {
-        x: positionX,
-        y: positionY,
+        x: Math.round(positionX),
+        y: Math.round(positionY),
         height: clientGeometry.height,
         width: clientGeometry.width,
     }


### PR DESCRIPTION
Warning: Untested! This is the first time I'm writing/changing a KWin script, and I'm not even sure how to test it.

This commit should fix the issue in case either the display size or the window size is odd. In such cases, when dividing by two we end up positioning the window at half-pixel position, leading to a blurry window.

How to reproduce:

1. Open http://www.lagom.nl/lcd-test/sharpness.php in a browser.
2. Resize the window so either the width or the height is odd.
3. Press Meta+Num5 to center the window.
4. BUG: Observe how blurry it is.

![Screenshot showing a blurry sharpness test](https://user-images.githubusercontent.com/121676/202409114-f19cdaae-7ee2-45e2-8f69-582de8441bc0.png)